### PR TITLE
Fix collapsed background color in OneUIView

### DIFF
--- a/lib/src/widgets/view/view.dart
+++ b/lib/src/widgets/view/view.dart
@@ -218,6 +218,7 @@ class _OneUIViewState extends State<OneUIView> {
       child: SizedBox(
         height: collapsedHeight,
         child: OneUIAppBar(
+          backgroundColor: widget.backgroundColor,
           backwardsCompatibility: false,
           title: FadeTransition(
             opacity: Tween(begin: 1.0, end: 0.0).animate(


### PR DESCRIPTION
Hi, thank you for the awesome plugin using my source!

How about changing the background color of the OneUIAppBar when using the `backgroundColor` property? Currently, this looks weird because of only changed the background color of the expanded title.