### PR TITLE
Fix default value of icon_button splashRadius

### DIFF
--- a/lib/src/widgets/buttons/icon_button.dart
+++ b/lib/src/widgets/buttons/icon_button.dart
@@ -121,7 +121,7 @@ class OneUIIconButton extends IconButton {
         radius: splashRadius ??
             math.max(
               Material.defaultSplashRadius,
-              (iconSize + math.min(padding.horizontal, padding.vertical)) * 0.7,
+              (iconSize ?? 24 + math.min(padding.horizontal, padding.vertical)) * 0.7,
               // x 0.5 for diameter -> radius and + 40% overflow derived from other Material apps.
             ),
       ),


### PR DESCRIPTION
There was a build-time problem due to incorrect null checking.
I set a default value of iconSize and now it can be built successfully.